### PR TITLE
To enable notification sound when app is in background

### DIFF
--- a/src/android/ParsePushPluginReceiver.java
+++ b/src/android/ParsePushPluginReceiver.java
@@ -104,6 +104,10 @@ public class ParsePushPluginReceiver extends ParsePushBroadcastReceiver
 			builder.setContentText(pnData.optString("alert"));
 		}
 		
+		if (!ParsePushPlugin.isInForeground()) { 
+			builder.setSound(android.provider.Settings.System.DEFAULT_NOTIFICATION_URI);
+		}
+		
 		builder.setSmallIcon(getSmallIconId(context, intent))
 		       .setLargeIcon(getLargeIcon(context, intent))
 		       .setNumber(nextCount(pnTag))


### PR DESCRIPTION
The sound will only pop when the app is in background. It will still have silent effect when the app is in foreground.