### PR TITLE
Fix crash on getSubscriptions when channel field is empty on parse

### DIFF
--- a/src/android/ParsePushPlugin.java
+++ b/src/android/ParsePushPlugin.java
@@ -86,8 +86,12 @@ public class ParsePushPlugin extends CordovaPlugin {
     private void getSubscriptions(final CallbackContext callbackContext) {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
-            	List<String> subscriptions = ParseInstallation.getCurrentInstallation().getList("channels");
-                callbackContext.success(subscriptions.toString());
+                List<String> subscriptions = ParseInstallation.getCurrentInstallation().getList("channels");
+                String subscriptionsString = "";
+                if (subscriptions != null) {
+                    subscriptionsString = subscriptions.toString();
+                }
+                callbackContext.success(subscriptionsString);
             }
         });
     }


### PR DESCRIPTION
When no subscriptions has been defined on an Installation yet, a call to ParsePushPlugin.getSubscriptions() provokes a crash:

    10-27 14:31:15.474: E/AndroidRuntime(17706): FATAL EXCEPTION: pool-4-thread-2
    10-27 14:31:15.474: E/AndroidRuntime(17706): Process: com.ionicframework.magnus223266, PID: 17706
    10-27 14:31:15.474: E/AndroidRuntime(17706): java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.Object.toString()' on a null object reference
    10-27 14:31:15.474: E/AndroidRuntime(17706):     at com.phonegap.parsepushplugin.ParsePushPlugin$3.run(ParsePushPlugin.java:90)
    10-27 14:31:15.474: E/AndroidRuntime(17706):     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
    10-27 14:31:15.474: E/AndroidRuntime(17706):     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
    10-27 14:31:15.474: E/AndroidRuntime(17706):     at java.lang.Thread.run(Thread.java:818)

The ParseObject.getList method "returns null if there is no such key or if the value can't be converted to a List." as per the Parse documentation:
https://parse.com/docs/android/api/com/parse/ParseObject.html#getList%28java.lang.String%29

This commit defaults the result to an empty string if ParseInstallation.getCurrentInstallation().getList("channels") returns null.