### PR TITLE
fix cold start notification queue

### DIFF
--- a/src/ios/ParsePushPlugin.h
+++ b/src/ios/ParsePushPlugin.h
@@ -4,7 +4,7 @@
 @interface ParsePushPlugin: CDVPlugin
 
 @property (nonatomic, copy) NSString* callbackId;
-@property (nonatomic, copy) NSMutableArray* pnQueue;
+@property (nonatomic, retain) NSMutableArray* pnQueue;
 
 //
 // methods exposed to JS


### PR DESCRIPTION
When receiving notification (app not started), the code crashes when opening the notification. I changed copy to retain on the mutable array. Then the queue was flushed before my listener is registered. So I differed the subscribe. I know this is not the cleanest way for fixing it. Let me know if you have a better idea.

Thanks for your work on this.