### PR TITLE
initialize method for iOS and android

### DIFF
--- a/src/android/ParsePushPlugin.java
+++ b/src/android/ParsePushPlugin.java
@@ -27,6 +27,7 @@ public class ParsePushPlugin extends CordovaPlugin {
    private static final String ACTION_SUBSCRIBE = "subscribe";
    private static final String ACTION_UNSUBSCRIBE = "unsubscribe";
    private static final String ACTION_REGISTER_CALLBACK = "registerCallback";
+   private static final String ACTION_INITIALIZE = "initialize";
 
    private static CallbackContext gEventCallback = null;
    private static Queue<PluginResult> pnQueue = new LinkedList();
@@ -66,6 +67,10 @@ public class ParsePushPlugin extends CordovaPlugin {
       }
       if (action.equals(ACTION_UNSUBSCRIBE)) {
          this.unsubscribe(args.getString(0), callbackContext);
+         return true;
+      }
+      if (action.equals(ACTION_INITIALIZE)) {
+         this.doInitialization(callbackContext);
          return true;
       }
       return false;
@@ -111,6 +116,10 @@ public class ParsePushPlugin extends CordovaPlugin {
    private void unsubscribe(final String channel, final CallbackContext callbackContext) {
     	ParsePush.unsubscribeInBackground(channel);
          callbackContext.success();
+   }
+
+   private void doInitialization(final CallbackContext callbackContext) {
+      callbackContext.success();
    }
 
    /*

--- a/src/ios/AppDelegate+parsepush.m
+++ b/src/ios/AppDelegate+parsepush.m
@@ -90,8 +90,9 @@ void MethodSwizzle(Class c, SEL originalSelector) {
       //
       ParsePushPlugin* pluginInstance = [self getParsePluginInstance];
 
-      NSString *appId     = [pluginInstance getConfigForKey:@"ParseAppId"];
-      NSString *serverUrl = [pluginInstance getConfigForKey:@"ParseServerUrl"];
+      NSString *appId      = [pluginInstance getConfigForKey:@"ParseAppId"];
+      NSString *serverUrl  = [pluginInstance getConfigForKey:@"ParseServerUrl"];
+      NSString *shouldInit = [pluginInstance getConfigForKey:@"ParseAutoRegistration"];
 
       if(!appId.length){
          NSException* invalidSettingException = [NSException
@@ -124,11 +125,12 @@ void MethodSwizzle(Class c, SEL originalSelector) {
          }]];
       }
 
-
-      UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound);
-      UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:userNotificationTypes categories:nil];
-      [application registerUserNotificationSettings:settings];
-      [application registerForRemoteNotifications];
+      if (!shouldInit.length || [shouldInit isEqualToString:@"true"]){
+        UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound);
+        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:userNotificationTypes categories:nil];
+        [application registerUserNotificationSettings:settings];
+        [application registerForRemoteNotifications];
+      }
 	}
 
    return isOk;

--- a/src/ios/ParsePushPlugin.h
+++ b/src/ios/ParsePushPlugin.h
@@ -10,6 +10,7 @@
 // methods exposed to JS
 - (void)registerCallback: (CDVInvokedUrlCommand*)command;
 
+- (void)initialize: (CDVInvokedUrlCommand *)command;
 - (void)getInstallationId: (CDVInvokedUrlCommand*)command;
 - (void)getInstallationObjectId: (CDVInvokedUrlCommand*)command;
 

--- a/src/ios/ParsePushPlugin.m
+++ b/src/ios/ParsePushPlugin.m
@@ -30,6 +30,22 @@
     }
 }
 
+- (void)initialize:(CDVInvokedUrlCommand *)command
+{
+    CDVPluginResult* pluginResult = nil;   
+    
+    NSString *shouldInit = [self getConfigForKey:@"ParseAutoRegistration"];
+    if ([shouldInit isEqualToString:@"false"]){
+        UIUserNotificationType userNotificationTypes = (UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound);
+        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:userNotificationTypes categories:nil];
+        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+        [[UIApplication sharedApplication] registerForRemoteNotifications];
+    }
+    
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void)getInstallationId:(CDVInvokedUrlCommand*) command
 {
     [self.commandDelegate runInBackground:^{

--- a/www/parse-push-plugin.js
+++ b/www/parse-push-plugin.js
@@ -66,6 +66,10 @@ var ParsePushPlugin = {
    unsubscribe: function(channel, successCb, errorCb) {
       cordova.exec(successCb, errorCb, serviceName, 'unsubscribe', [ channel ]);
    },
+
+   initialize: function(successCb, errorCb) {
+      cordova.exec(successCb, errorCb, serviceName, 'initialize', []);
+   },
 };
 
 //


### PR DESCRIPTION
A quick implementation of features based on discussion in this issue -> https://github.com/taivo/parse-push-plugin/issues/48

Android initialize currently does nothing as you don't need to request permission for push.

Looking at the code... it appears that "subscribe" would request permission for push as well... but having  a method specifically for this might be cleaner?