### PR TITLE
Add ability to send Client Key to parse server.

### DIFF
--- a/src/android/ParsePushApplication.java
+++ b/src/android/ParsePushApplication.java
@@ -60,13 +60,14 @@ public class ParsePushApplication extends Application {
          if(config.getServerUrl().equalsIgnoreCase("PARSE_DOT_COM")){
             //
             //initialize for use with legacy parse.com
-            Parse.initialize(this, config.getAppId(), config.get("ParseClientKey"));
+            Parse.initialize(this, config.getAppId(), config.getClientKey());
          } else{
             //
             // initialize for use with opensource parse-server
             Parse.initialize(new Parse.Configuration.Builder(this)
                .applicationId(config.getAppId())
                .server(config.getServerUrl()) // The trailing slash is important, e.g., https://mydomain.com:1337/parse/
+               .clientKey(config.getClientKey()) // Can be null 
                .build()
             );
          }

--- a/src/android/ParsePushConfigReader.java
+++ b/src/android/ParsePushConfigReader.java
@@ -29,8 +29,8 @@ public final class ParsePushConfigReader {
    //
    private static final String parseAppIdKey = "ParseAppId";
    private static final String parseServerUrlKey = "ParseServerUrl";
-   
-   // ParseClientKey is not required by parse server, but can be required for some environments
+
+   // ParseClientKey is not required by parse server, but can be required by some environments
    private static final String parseClientKeyKey = "ParseClientKey";
 
 

--- a/src/android/ParsePushConfigReader.java
+++ b/src/android/ParsePushConfigReader.java
@@ -29,6 +29,9 @@ public final class ParsePushConfigReader {
    //
    private static final String parseAppIdKey = "ParseAppId";
    private static final String parseServerUrlKey = "ParseServerUrl";
+   
+   // ParseClientKey is not required by parse server, but can be required for some environments
+   private static final String parseClientKeyKey = "ParseClientKey";
 
 
    private List<String> supportedKeys = new ArrayList(Arrays.asList(parseAppIdKey, parseServerUrlKey));
@@ -58,6 +61,10 @@ public final class ParsePushConfigReader {
 
    public String getServerUrl(){
       return configs.get(parseServerUrlKey);
+   }
+
+   public String getClientKey(){
+       return configs.get(parseClientKeyKey);
    }
 
    public String get(String key){

--- a/src/ios/AppDelegate+parsepush.m
+++ b/src/ios/AppDelegate+parsepush.m
@@ -90,6 +90,7 @@ void MethodSwizzle(Class c, SEL originalSelector) {
 
       NSString *appId      = [pluginInstance getConfigForKey:@"ParseAppId"];
       NSString *serverUrl  = [pluginInstance getConfigForKey:@"ParseServerUrl"];
+      NSString *clientKey  = [pluginInstance getConfigForKey:@"ParseClientKey"];
       NSString *autoReg = [pluginInstance getConfigForKey:@"ParseAutoRegistration"];
 
       if(!appId.length){
@@ -112,7 +113,7 @@ void MethodSwizzle(Class c, SEL originalSelector) {
          //
          // initialize for use with parse.com
          //
-         [Parse setApplicationId:appId clientKey:[pluginInstance getConfigForKey:@"ParseClientKey"]];
+         [Parse setApplicationId:appId clientKey:clientKey];
       } else{
          //
          // initialize for use with opensource parse-server
@@ -120,6 +121,7 @@ void MethodSwizzle(Class c, SEL originalSelector) {
          [Parse initializeWithConfiguration:[ParseClientConfiguration configurationWithBlock:^(id<ParseMutableClientConfiguration> configuration) {
             configuration.applicationId = appId;
             configuration.server = serverUrl;
+            configuration.clientKey = clientKey;
          }]];
       }
 


### PR DESCRIPTION
The client keys used with Parse are no longer necessary with Parse Server, however you could still require them.  

The parse push plugin wasn't able to send the client key.

This pull request try to fix this issue.



