### PR TITLE
Optional ability to override standard behaviour of a single notification in android notification tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Parse.Push plugin for Cordova/Phonegap/ionic. Works for both hosted Parse.com an
 
    *Android*: to prevent flooding the notification tray, this plugin retains only the last PN with the same `title` field. For messages without the `title` field, the application name is used. A count of unopened PNs is shown.
 
+   You can override this feature, however, by adding the following to `config.xml`:
+
+   ```xml
+   <preference name="ParseMultiNotifications" value="true" />
+   ```
+
 
 #### Foreground vs. Background
 
@@ -139,6 +145,10 @@ Create the following tags in `config.xml`:
       This is the same "senderId" to be used in your parse-server push configuration.
    -->
    <preference name="ParseGcmSenderId" value="gcm-sender-id" />
+
+   <!-- As standard, this plugin only shows the most recent PN in the android notifications tray along with a count of unopened PNs. If you would like to override this behaviour and show all PNs in the tray, then add this preference. 
+     If not, skip this preference-->
+   <preference name="ParseMultiNotifications" value="true" />
    ```
 
    - For legacy Parse.com
@@ -149,6 +159,10 @@ Create the following tags in `config.xml`:
 
    <!-- Do not replace this string value. It must be "PARSE_DOT_COM"-->
    <preference name="ParseServerUrl" value="PARSE_DOT_COM" />
+
+   <!-- As standard, this plugin only shows the most recent PN in the android notifications tray along with a count of unopened PNs. If you would like to override this behaviour and show all PNs in the tray, then add this preference. 
+     If not, skip this preference-->
+   <preference name="ParseMultiNotifications" value="true" />
    ```
 
 You're all set. The plugin takes care of initializing Parse platform using the `config.xml` preferences mentioned above. It also saves your installation to the database automatically.

--- a/README.md
+++ b/README.md
@@ -146,8 +146,11 @@ Create the following tags in `config.xml`:
    -->
    <preference name="ParseGcmSenderId" value="gcm-sender-id" />
 
-   <!-- As standard, this plugin only shows the most recent PN in the android notifications tray along with a count of unopened PNs. If you would like to override this behaviour and show all PNs in the tray, then add this preference. 
-     If not, skip this preference-->
+   <!-- As standard, this plugin only shows the most recent PN in 
+      the android notifications tray along with a count of unopened 
+      PNs. If you would like to override this behaviour and show all 
+      PNs in the tray, then add this preference. 
+      If not, skip this preference -->
    <preference name="ParseMultiNotifications" value="true" />
    ```
 
@@ -160,8 +163,11 @@ Create the following tags in `config.xml`:
    <!-- Do not replace this string value. It must be "PARSE_DOT_COM"-->
    <preference name="ParseServerUrl" value="PARSE_DOT_COM" />
 
-   <!-- As standard, this plugin only shows the most recent PN in the android notifications tray along with a count of unopened PNs. If you would like to override this behaviour and show all PNs in the tray, then add this preference. 
-     If not, skip this preference-->
+   <!-- As standard, this plugin only shows the most recent PN in 
+      the android notifications tray along with a count of unopened
+      PNs. If you would like to override this behaviour and show all
+      PNs in the tray, then add this preference. 
+      If not, skip this preference -->
    <preference name="ParseMultiNotifications" value="true" />
    ```
 

--- a/src/android/ParsePushConfigReader.java
+++ b/src/android/ParsePushConfigReader.java
@@ -33,7 +33,6 @@ public final class ParsePushConfigReader {
    // ParseClientKey is not required by parse server, but can be required by some environments
    private static final String parseClientKeyKey = "ParseClientKey";
 
-
    private List<String> supportedKeys = new ArrayList(Arrays.asList(parseAppIdKey, parseServerUrlKey));
    private Map<String, String> configs;
 


### PR DESCRIPTION
I need to show multiple notifications in the Android notification tray with the same title. I can understand that there are cases where you would only want to show the last PN and a count of unopened PNs. This is perfectly fine as the default behaviour. 

So, in order to make things a little more flexible, I've added the ability to override the default behaviour by adding a preference to `config.xml`. 

```xml
<preference name="ParseMultiNotifications" value="true" />
```

Leaving this preference out will not cause any issues but allows certain use cases to be easily adopted with its addition.

Happy to take any feedback on what I have committed. 