### PR TITLE
Fix search config.xml

### DIFF
--- a/scripts/afterAndroidPrepare.js
+++ b/scripts/afterAndroidPrepare.js
@@ -7,7 +7,7 @@ module.exports = function(context) {
    var ET = context.requireCordovaModule('elementtree');
    var ConfigFile = context.requireCordovaModule("cordova-common").ConfigFile;
 
-   var configXml = new ConfigFile(context.opts.projectRoot, null, 'config.xml');
+   var configXml = new ConfigFile(context.opts.projectRoot, null, './config.xml');
 
    //
    // detect parse.com or parse-server mode


### PR DESCRIPTION
Fix this error:
Error: Cannot read property 'get' of null

After debugging the file scripts scripts/afterAndroidPrepare.js,I found that he seeks all config.xml files, and case bower repository has this file, in my case the imgcache framework, was giving conflict, but this correction it will read only the main file ./config.xml, eliminating like any other file and avoid this error