### PR TITLE
log Android installation flow for easier debugging

### DIFF
--- a/src/android/ParsePushApplication.java
+++ b/src/android/ParsePushApplication.java
@@ -63,17 +63,21 @@ public class ParsePushApplication extends Application {
             //
             //initialize for use with legacy parse.com
             Parse.initialize(this, config.getAppId(), config.getClientKey());
-         } else{
+         } else {
+            Log.d(LOGTAG, "ServerUrl " + config.getServerUrl());
+            Log.d(LOGTAG, "NOTE: The trailing slash is important, e.g., https://mydomain.com:1337/parse/");
+            Log.d(LOGTAG, "NOTE: Set the clientKey if your server requires it, otherwise it can be null");
             //
             // initialize for use with opensource parse-server
             Parse.initialize(new Parse.Configuration.Builder(this)
                .applicationId(config.getAppId())
-               .server(config.getServerUrl()) // The trailing slash is important, e.g., https://mydomain.com:1337/parse/
-               .clientKey(config.getClientKey()) // Can be null 
+               .server(config.getServerUrl())
+               .clientKey(config.getClientKey())
                .build()
             );
          }
 
+         Log.d(LOGTAG, "Saving Installation in background");
          //
          // save installation. Parse.Push will need this to push to the correct device
          ParseInstallation.getCurrentInstallation().saveInBackground(new SaveCallback() {

--- a/src/android/ParsePushApplication.java
+++ b/src/android/ParsePushApplication.java
@@ -5,6 +5,8 @@ import android.app.Application;
 import com.parse.Parse;
 import com.parse.Parse.Configuration.Builder;
 import com.parse.ParseInstallation;
+import com.parse.SaveCallback;
+import com.parse.ParseException;
 
 import github.taivo.parsepushplugin.ParsePushConfigReader;
 import github.taivo.parsepushplugin.ParsePushConfigException;
@@ -74,7 +76,16 @@ public class ParsePushApplication extends Application {
 
          //
          // save installation. Parse.Push will need this to push to the correct device
-         ParseInstallation.getCurrentInstallation().saveInBackground();
+         ParseInstallation.getCurrentInstallation().saveInBackground(new SaveCallback() {
+            @Override
+            public void done(ParseException ex) {
+               if (null != ex) {
+                  Log.e(LOGTAG, ex.toString());
+               } else {
+                  Log.d(LOGTAG, "Installation saved");
+               }
+            }
+         });
 
       } catch(ParsePushConfigException ex){
          Log.e(LOGTAG, ex.toString());


### PR DESCRIPTION
I moved the comments into Log.d so that it's easier to surface.
I also log the exception returned when the saving of ParseInstallation in background failed.

In my case, I try to leverage Cloudflare & Heroku free SSL to enable https for free.
I think the Universal SSL free plan that Cloudflare offers is not compatiable with Parse Android SDK leading to a `com.parse.ParseRequest$ParseRequestException: i/o failure`, but it was not easy to arrive at this as the log is swallowed from Parse side.

