### PR TITLE
iOS 10 push notifications

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin xmlns="http://www.apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="parse-push-plugin" version="1.0.6">
+<plugin xmlns="http://www.apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="parse-push-plugin" version="1.0.7">
    <name>ParsePushPlugin</name>
    <description>Parse.Push plugin for phonegap/cordova/ionic framework</description>
 	<keywords>cordova,phonegap,ionic framework, parse server, parse push, push notification</keywords>

--- a/src/ios/ParsePushPlugin.h
+++ b/src/ios/ParsePushPlugin.h
@@ -1,7 +1,8 @@
 #import <Cordova/CDV.h>
 #import "AppDelegate.h"
+#import <UserNotifications/UserNotifications.h>
 
-@interface ParsePushPlugin: CDVPlugin
+@interface ParsePushPlugin: CDVPlugin <UNUserNotificationCenterDelegate>
 
 @property bool hasRegistered;
 @property (copy) NSString* callbackId;


### PR DESCRIPTION
The changes are fairly minor, thankfully!

I've essentially added @otmezger's code, which should be the bare minimum for UN setup under iOS10. 

Also removed the registration calls from the `subscribe` method.

Please note I haven't done extensive testing, nor am I well versed in iOS dev!

With the changes in this pull request I was able to register a device and store a token in Parse (hosted install) with iOS 10, 10.2, and 9.3.5.

Hope this helps!

(The commits are done using my work-centric github account, apologies if that causes any confusion)