### PR TITLE
Fix receiving notifications when app is running in background.

### DIFF
--- a/src/ios/ParsePushPlugin.m
+++ b/src/ios/ParsePushPlugin.m
@@ -197,6 +197,10 @@
 
 -(void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)())completionHandler {
     NSLog(@"User info %@", response.notification.request.content.userInfo);
+    
+    [self jsCallback:response.notification.request.content.userInfo withAction: @"OPEN"];
+    
+    completionHandler();
 }
 
 @end


### PR DESCRIPTION
# Problem
While the app is running in background, no push notification events can be received in iOS.

# Solution
As mentioned by @Schwobaland in #92 the JS callback has to be called.