### PR TITLE
Fixing getSubscriptions on Android-Devices

### DIFF
--- a/src/android/ParsePushPlugin.java
+++ b/src/android/ParsePushPlugin.java
@@ -105,11 +105,11 @@ public class ParsePushPlugin extends CordovaPlugin {
       cordova.getThreadPool().execute(new Runnable() {
          public void run() {
             List<String> subscriptions = ParseInstallation.getCurrentInstallation().getList("channels");
-            JSONArray subscripptionsArray = new JSONArray();
+            JSONArray subscriptionsArray = new JSONArray();
             if (subscriptions != null) {
-               subscripptionsArray = new JSONArray(subscriptions);
+               subscriptionsArray = new JSONArray(subscriptions);
             }
-            callbackContext.success(subscripptionsArray);
+            callbackContext.success(subscriptionsArray);
          }
       });
    }

--- a/src/android/ParsePushPlugin.java
+++ b/src/android/ParsePushPlugin.java
@@ -105,11 +105,11 @@ public class ParsePushPlugin extends CordovaPlugin {
       cordova.getThreadPool().execute(new Runnable() {
          public void run() {
             List<String> subscriptions = ParseInstallation.getCurrentInstallation().getList("channels");
-            String subscriptionsString = "";
+            JSONArray subscripptionsArray = new JSONArray();
             if (subscriptions != null) {
-               subscriptionsString = subscriptions.toString();
+               subscripptionsArray = new JSONArray(subscriptions);
             }
-            callbackContext.success(subscriptionsString);
+            callbackContext.success(subscripptionsArray);
          }
       });
    }
@@ -150,7 +150,7 @@ public static void jsCallback(JSONObject _json, String pushAction){
 			else
 				dataResult = new PluginResult(PluginResult.Status.OK, cbParams);
 		} else {
-			dataResult = new PluginResult(PluginResult.Status.OK, _json); 
+			dataResult = new PluginResult(PluginResult.Status.OK, _json);
 		}
 	  dataResult.setKeepCallback(true);
 


### PR DESCRIPTION
`getSubscriptions()` on Android-Devices didn't return something, because of a not formatted string.
On iOS getSubscriptions returned an array. On Android getSubscriptions returned a string formatted like this: `[channel1, channel2, channel3]`. This was not even a JSON-Array because quotation marks were missing.
This pull-request changes android-behavior to return an array.