### PR TITLE
As of Android 26 a Notification channel is required for push notifications to work correctly

### DIFF
--- a/src/android/ParsePushPluginReceiver.java
+++ b/src/android/ParsePushPluginReceiver.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.app.PendingIntent;
 import android.app.Notification;
 import android.app.NotificationManager;
+import android.app.NotificationChannel;
 
 import github.taivo.parsepushplugin.ParsePushConfigReader;
 
@@ -33,6 +34,8 @@ import me.leolin.shortcutbadger.ShortcutBadger;
 public class ParsePushPluginReceiver extends ParsePushBroadcastReceiver {
   public static final String LOGTAG = "ParsePushPluginReceiver";
   public static final String RESOURCE_PUSH_ICON_COLOR = "parse_push_icon_color";
+  private static final String DEFAULT_CHANNEL_ID = "parse_push";
+  private static final String DEFAULT_CHANNEL_TITLE = "Default Channel";
 
   private static JSONObject MSG_COUNTS = new JSONObject();
   private static int badgeCount = 0;
@@ -144,7 +147,18 @@ public class ParsePushPluginReceiver extends ParsePushBroadcastReceiver {
     PendingIntent deleteIntent = PendingIntent.getBroadcast(context, deleteIntentRequestCode, dIntent,
         PendingIntent.FLAG_UPDATE_CURRENT);
 
-    NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+    int importance = NotificationManager.IMPORTANCE_HIGH;
+    NotificationManager notifManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    NotificationChannel mChannel = notifManager.getNotificationChannel(DEFAULT_CHANNEL_ID);
+
+    if (mChannel == null) {
+      mChannel = new NotificationChannel(DEFAULT_CHANNEL_ID, DEFAULT_CHANNEL_TITLE, importance);
+      mChannel.enableVibration(true);
+      mChannel.setVibrationPattern(new long[]{100, 200, 300, 400, 500, 400, 300, 200, 400});
+      notifManager.createNotificationChannel(mChannel);
+    }
+
+    NotificationCompat.Builder builder = new NotificationCompat.Builder(context, DEFAULT_CHANNEL_ID);
 
     // check if this is a silent notification
     boolean isSilent = !pnData.has("title") && !pnData.has("alert");


### PR DESCRIPTION
After targeting Android sdk version 26 I was getting this error message:
NotificationService: No Channel found for <app_name>

According to this documentation: https://developer.android.com/training/notify-user/channels
> Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel.

I've added code to create the default channel.

Inspiration came from this stack overflow post:
https://stackoverflow.com/questions/46990995/on-android-8-1-api-27-notification-does-not-display