### PR TITLE
Fix xcode error "must be run on main thread"

### DIFF
--- a/src/ios/ParsePushPlugin.m
+++ b/src/ios/ParsePushPlugin.m
@@ -114,7 +114,9 @@
 
             [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error){
                 if( !error ){
-                    [application registerForRemoteNotifications];
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [application registerForRemoteNotifications];
+                    });
                 }
             }];
 


### PR DESCRIPTION
As this uses UIApplication xcode throws errors about the task being run on a background thread.  To resolve run async on main thread so there are no errors and xcode (and consequently appstore reviews) are happy.