### PR TITLE
Update Bolts branch to `main`

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -95,7 +95,7 @@
 	     <source url="https://github.com/CocoaPods/Specs.git"/>
 	</config>
 	<pods use-frameworks="true">
-	     <pod name="Bolts" git="https://github.com/BoltsFramework/Bolts-ObjC" branch="master" />
+	     <pod name="Bolts" git="https://github.com/BoltsFramework/Bolts-ObjC" branch="main" />
 	</pods>
       </podspec>
    </platform>


### PR DESCRIPTION
Bolts repo has updated their primary branch from `master` to `main` (https://github.com/BoltsFramework/Bolts-ObjC/tree/main)